### PR TITLE
Add the ability to supply user-defined state key.

### DIFF
--- a/src/smart.ts
+++ b/src/smart.ts
@@ -163,7 +163,7 @@ export async function authorize(
         width,
         height,
         pkceMode,
-        clientPublicKeySetUrl
+        clientPublicKeySetUrl,
     } = params;
 
     let {
@@ -175,7 +175,8 @@ export async function authorize(
         scope = "",
         clientId,
         completeInTarget,
-        clientPrivateJwk
+        clientPrivateJwk,
+        stateKey
     } = params;
 
     const storage = env.getStorage();
@@ -247,8 +248,9 @@ export async function authorize(
     const oldKey = await storage.get(SMART_KEY);
     await storage.unset(oldKey);
 
-    // create initial state
-    const stateKey = randomString(16);
+    stateKey = stateKey ?? randomString(16);
+
+    // Create initial state
     const state: fhirclient.ClientState = {
         clientId,
         scope,

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -634,6 +634,25 @@ declare namespace fhirclient {
          *    this setting
          */
         pkceMode?: PkceMode;
+
+        /**
+         * An opaque value used by the client to maintain state between the request and callback.
+         *
+         * If stateKey is not specified, one will be generated automatically.
+         *
+         * The authorization server includes this value when redirecting the user-agent back to the
+         * client.
+         *
+         * It's important to ensure that no sensitive information is included in the state
+         * parameter because it could be saved in the browser's history or server logs. To prevent
+         * CSRF attacks, the state parameter should be generated with a secure random seed.
+         *
+         * From the perspective of developing client applications, the state parameter is useful
+         * for restoring a user's session, which might involve querying a data structure for cached
+         * objects specific to that user. The state parameter could refer to a user session key,
+         * but its purpose may vary depending on the application.
+         */
+        stateKey?: string;
     }
 
     interface ReadyOptions {


### PR DESCRIPTION
Current Node examples of storing user session with a custom storage implementation include generating a unique ID, and distinguishing between user states with this unique ID. This ID is not related to the state key that is generated by the fhirclient library.

In this Pull Request, I am proposing a change where the user of this library can supply their own state key, and this could ostensibly be the same unique identifier that's used for distinguishing users in whatever custom storage solution is implemented. The benefit to this approach is that the state key is already being passed along in the redirect, so one does not have to set cookies in order to recall which user is which. This seems to be more in line with how the state parameter was intended to be used in the OAuth flow.